### PR TITLE
feat: Tazamafy Relay Service

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+## What did we change?
+
+## Why are we doing this?
+
+## How was it tested?
+- [ ] Locally
+- [ ] Development Environment
+- [ ] Not needed, changes very basic
+- [ ] Husky successfully run
+- [ ] Unit tests passing and Documentation done

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: relay-service-rel-1-0-0
+  namespace: development
+  labels:
+    app: relay-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: relay-service
+  template:
+    metadata:
+      name: relay-service-rel-1-0-0
+      labels:
+        app: relay-service
+      annotations:
+        prometheus.io.scrape: 'false'
+    spec:
+      containers:
+        - name: relay-service-rel-1-0-0
+          image: example.io/relay-service-rel-1-0-0:1.0.0
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources: {}
+          imagePullPolicy: Always
+        - name: relay-sidecar-rel-1-0-0
+          image: example.io/sidecar-rel-1-0-0:1.0.0
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 5000
+          resources: {}
+          imagePullPolicy: Always
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      imagePullSecrets:
+        - name: frmpullsecret
+      schedulerName: default-scheduler
+      enableServiceLinks: false
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: relay-service-rel-1-0-0
+  namespace: development
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: relay-service
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Tazamafy the relay service by adding the service.yaml and deployment.yaml (with a sidecar for logging)

## Why are we doing this?
Make the Tazama service ready for our Jenkins deployment setup

## How was it tested?
- [x] Locally
- [x] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done