### PR TITLE
fix: add codewoners file to test with

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Please do not attempt to edit this file without the direct consent from the DevOps team. This file is managed centrally.
+# Contact @scott45
+
+* @Justus-at-Tazama @Lenbkr @cshezi @rtkay123 @JeanPierreNell
+/.github/ @scott45


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Add code-owners 

## Why are we doing this?
Ease management and code review

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
