### PR TITLE
build: bump @tazama-lf deps to rc and update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-# Please do not attempt to edit this file without the direct consent from the DevOps team. This file is managed centrally.
-# Contact @scott45
-
-* @Justus-at-Tazama @Sandy-at-Tazama
-/.github/ @scott45
+* @tazama-lf/core-codeowners @tazama-lf/community-codeowners

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "message-relay-service",
-  "version": "3.0.0",
+  "version": "4.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "message-relay-service",
-      "version": "3.0.0",
+      "version": "4.0.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "6.0.0",
-        "@tazama-lf/frms-coe-startup-lib": "3.0.0",
+        "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
+        "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2",
         "amqplib": "^0.10.8",
         "axios": "^1.12.1",
         "dotenv": "^17.2.0",
@@ -84,7 +84,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1931,7 +1930,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2194,9 +2192,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "6.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0/43da7d6f911c00953831e0f59cd0fe2a43623c6b",
-      "integrity": "sha512-7QzbhD2TM6u4expnTwXni/NC1BRycsTN2p/LGPH13mugb3aOFng/0UHaj83v/WQ3P5QoHzSfqFQppx4RuVH3Mw==",
+      "version": "7.0.2-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/7.0.2-rc.2/5a47489d4d9a0154426dfe16d37e958c7ede24c5",
+      "integrity": "sha512-c8AXQpVPoRwxoQj1gMA9vEZN0AQEijp+6zXRb9ADToV1gMt+UbY0fmX+uFxmGrprB7OdP9N3YS5OPwD7if4MCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2209,6 +2207,7 @@
         "ioredis": "^5.7.0",
         "node-cache": "^5.1.2",
         "pg": "8.16.3",
+        "pg-format": "^1.0.4",
         "pino": "^9.9.0",
         "pino-elasticsearch": "^8.1.0",
         "protobufjs": "^7.5.4",
@@ -2216,16 +2215,16 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.0/ff86f7256d139056b942d831125becc51b6e1b17",
-      "integrity": "sha512-x7g0EOiCmR0FrqViz2MtMp9Tg4GOnruOB5PwX9pT1ps5aUfF6jp6NiNU4wRt/Y0x0sOYO4uXF/PIlAWVDCD/ew==",
+      "version": "3.0.2-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.2-rc.2/4c73fb8b2186d6cb1ba927d6c6eede58d65e1c1d",
+      "integrity": "sha512-0puBZ+bWUjCxTO/wggn9dHRX5gxHvCXo/Z6w/Mw/ODY5pLqxOzSOv///OVZmgolFQ5s+iUCfDCnpX3tMOiSLoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/bigquery": "^8.1.1",
         "@google-cloud/storage": "^7.16.0",
-        "@tazama-lf/frms-coe-lib": "6.0.0",
+        "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
         "amqplib": "0.10.6",
-        "axios": "^1.12.2",
+        "axios": "^1.13.5",
         "google-auth-library": "^10.2.0",
         "nats": "^2.29.3"
       }
@@ -2429,7 +2428,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2576,7 +2574,6 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -3056,7 +3053,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3510,14 +3506,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3793,7 +3789,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -5224,7 +5219,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6114,9 +6108,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7704,7 +7698,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9735,7 +9728,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9770,6 +9762,15 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
       "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
       "license": "MIT"
+    },
+    "node_modules/pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -10409,10 +10410,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -12042,7 +12046,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12249,7 +12252,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-relay-service",
-  "version": "3.0.0",
+  "version": "4.0.0-rc.0",
   "description": "Tazama relay service wrapper for point-to-point message relay",
   "main": "src/index.js",
   "repository": {
@@ -26,8 +26,8 @@
   "author": "Tazama.org",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "6.0.0",
-    "@tazama-lf/frms-coe-startup-lib": "3.0.0",
+    "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
+    "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2",
     "amqplib": "^0.10.8",
     "axios": "^1.12.1",
     "dotenv": "^17.2.0",


### PR DESCRIPTION
## Summary

Bumps @tazama-lf dependencies to latest rc versions and updates repo housekeeping.

### Dependency updates

| Package | From | To |
|---------|------|----|
| @tazama-lf/frms-coe-lib | 6.0.0 | 7.0.2-rc.2 |
| @tazama-lf/frms-coe-startup-lib | 3.0.0 | 3.0.2-rc.2 |

### Version bump

3.0.0 -> 4.0.0-rc.0

### CI changes

- Removed CHANGELOG.md and VERSION (if present)
- Updated .github/CODEOWNERS: * @tazama-lf/core-codeowners @tazama-lf/community-codeowners