### PR TITLE
fix: use BuildKit secret for GH_TOKEN (tazama-lf/workflows#52)

### DIFF
--- a/.github/workflows/dockerhub-image-build-rc.yml
+++ b/.github/workflows/dockerhub-image-build-rc.yml
@@ -65,7 +65,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -65,7 +65,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 # Developed By Paysys Labs
 
 # Use Node.js as the base image
 FROM node:20-alpine
 
-ARG GH_TOKEN
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -14,7 +14,7 @@ COPY package*.json ./
 COPY .npmrc .npmrc
 
 # Install dependencies
-RUN npm install
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm install
 
 # Copy the rest of the application code to the container
 COPY . .

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -1,10 +1,10 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 # Developed By Paysys Labs
 
 # Use Node.js as the base image
 FROM node:20-alpine
 
-ARG GH_TOKEN
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -14,7 +14,7 @@ COPY package*.json ./
 COPY .npmrc .npmrc
 
 # Install dependencies, including the Kafka relay plugin
-RUN npm install && npm install @tazama-lf/kafka-relay-plugin
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm install && npm install @tazama-lf/kafka-relay-plugin
 
 # Copy the rest of the application code to the container
 COPY . .

--- a/Dockerfile.nats
+++ b/Dockerfile.nats
@@ -1,10 +1,10 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 # Developed By Paysys Labs
 
 # Use Node.js as the base image
 FROM node:20-alpine
 
-ARG GH_TOKEN
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -14,7 +14,7 @@ COPY package*.json ./
 COPY .npmrc .npmrc
 
 # Install dependencies, including the NATS relay plugin
-RUN npm install && npm install @tazama-lf/nats-relay-plugin
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm install && npm install @tazama-lf/nats-relay-plugin
 
 # Copy the rest of the application code to the container
 COPY . .

--- a/Dockerfile.rabbitmq
+++ b/Dockerfile.rabbitmq
@@ -1,10 +1,10 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 # Developed By Paysys Labs
 
 # Use Node.js as the base image
 FROM node:20-alpine
 
-ARG GH_TOKEN
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -14,7 +14,7 @@ COPY package*.json ./
 COPY .npmrc .npmrc
 
 # Install dependencies, including the NATS relay plugin
-RUN npm install && npm install @tazama-lf/rabbitmq-relay-plugin
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm install && npm install @tazama-lf/rabbitmq-relay-plugin
 
 # Copy the rest of the application code to the container
 COPY . .

--- a/Dockerfile.rest
+++ b/Dockerfile.rest
@@ -1,10 +1,10 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 # Developed By Paysys Labs
 
 # Use Node.js as the base image
 FROM node:20-alpine
 
-ARG GH_TOKEN
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -14,7 +14,7 @@ COPY package*.json ./
 COPY .npmrc .npmrc
 
 # Install dependencies, including the REST relay plugin
-RUN npm install && npm install @tazama-lf/rest-relay-plugin
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm install && npm install @tazama-lf/rest-relay-plugin
 
 # Copy the rest of the application code to the container
 COPY . .


### PR DESCRIPTION
Removes `ARG GH_TOKEN` from all build stages and replaces plain `npm ci` with
`RUN --mount=type=secret` so the GitHub PAT used for `npm install` is never
stored in image layer history (`docker history`).

Requires `# syntax=docker/dockerfile:1` directive at the top of the Dockerfile
to enable BuildKit extended RUN syntax.

Part of the coordinated migration tracked in tazama-lf/workflows#52.

**NOTE: Do not merge the canonical workflow PR (tazama-lf/workflows) until all
service repo Dockerfiles have been updated. See tazama-lf/workflows#52 for
rollout order.**