### PR TITLE
ci: sync workflows from central-workflows [skip ci]

### DIFF
--- a/.github/workflows/codacy-ci.yml
+++ b/.github/workflows/codacy-ci.yml
@@ -46,8 +46,14 @@ jobs:
       # Codacy outputs one SARIF run per engine. The CodeQL upload-sarif action rejects
       # files with multiple runs sharing the same category (enforced since 2025-07-21).
       # Merge all runs into one before uploading.
+      # Guard: when Codacy runs unauthenticated with no applicable findings it exits 0
+      # but does not write results.sarif. Create a minimal valid SARIF in that case so
+      # the upload step does not error on a missing or empty file.
       - name: Merge SARIF runs into single run
         run: |
+          if [ ! -s results.sarif ]; then
+            echo '{"$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"Codacy","rules":[]}},"results":[]}]}' > results.sarif
+          fi
           jq '
             if (.runs | length) > 1 then
               .runs = [{


### PR DESCRIPTION
This PR syncs workflows from the central-workflows repository.

Signed-off-by: Sandy-at-Tazama <Sandy-at-Tazama@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability by adding a guard mechanism to handle cases where the code analysis step completes successfully but produces no output file, preventing subsequent pipeline steps from failing unexpectedly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/relay-service/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->